### PR TITLE
#104: Remove remaining references to JAXM from API/Javadoc

### DIFF
--- a/api/src/main/java/jakarta/xml/soap/SOAPConnection.java
+++ b/api/src/main/java/jakarta/xml/soap/SOAPConnection.java
@@ -43,9 +43,7 @@ public abstract class SOAPConnection {
      * @param to an {@code Object} that identifies
      *         where the message should be sent. It is required to
      *         support Objects of type
-     *         {@code java.lang.String},
-     *         {@code java.net.URL}, and when JAXM is present
-     *         {@code javax.xml.messaging.URLEndpoint}
+     *         {@code java.lang.String} and {@code java.net.URL}
      *
      * @return the {@code SOAPMessage} object that is the response to the
      *         message that was sent

--- a/spec/src/main/asciidoc/appendix.adoc
+++ b/spec/src/main/asciidoc/appendix.adoc
@@ -35,6 +35,7 @@ http://www.ws-i.org/Profiles/AttachmentsProfile-1.0.html
 === Changes in Version 3.0
 
 * `SOAPElementFactory` has been removed
+* `SOAPConnection.call` is no longer required to support `javax.xml.messaging.URLEndpoint`
 
 === Changes in Version 2.0
 


### PR DESCRIPTION
Signed-off-by: Lukas Jungmann <lukas.jungmann@oracle.com>